### PR TITLE
Start making Zig build forward-compatible with 0.13

### DIFF
--- a/native/.gitignore
+++ b/native/.gitignore
@@ -1,4 +1,5 @@
 zig-cache/
+.zig-cache/
 zig-out/
 *.o
 *.a

--- a/native/build.zig
+++ b/native/build.zig
@@ -14,12 +14,12 @@ pub fn build(b: *std.Build) void {
     });
     const libpotrace_flags = .{ "-std=gnu17", "-DHAVE_CONFIG_H" };
     libpotrace.linkLibC();
-    libpotrace.addIncludePath(.{ .path = "lib/potrace-1.16/src" });
-    libpotrace.addIncludePath(.{ .path = "lib/potrace-config" });
-    libpotrace.addCSourceFile(.{ .file = .{ .path = "lib/potrace-1.16/src/curve.c" }, .flags = &libpotrace_flags });
-    libpotrace.addCSourceFile(.{ .file = .{ .path = "lib/potrace-1.16/src/trace.c" }, .flags = &libpotrace_flags });
-    libpotrace.addCSourceFile(.{ .file = .{ .path = "lib/potrace-1.16/src/decompose.c" }, .flags = &libpotrace_flags });
-    libpotrace.addCSourceFile(.{ .file = .{ .path = "lib/potrace-1.16/src/potracelib.c" }, .flags = &libpotrace_flags });
+    libpotrace.addIncludePath(b.path("lib/potrace-1.16/src"));
+    libpotrace.addIncludePath(b.path("lib/potrace-config"));
+    libpotrace.addCSourceFile(.{ .file = b.path("lib/potrace-1.16/src/curve.c"), .flags = &libpotrace_flags });
+    libpotrace.addCSourceFile(.{ .file = b.path("lib/potrace-1.16/src/trace.c"), .flags = &libpotrace_flags });
+    libpotrace.addCSourceFile(.{ .file = b.path("lib/potrace-1.16/src/decompose.c"), .flags = &libpotrace_flags });
+    libpotrace.addCSourceFile(.{ .file = b.path("lib/potrace-1.16/src/potracelib.c"), .flags = &libpotrace_flags });
 
     const libclipper2 = b.addStaticLibrary(.{
         .name = "clipper2",
@@ -30,54 +30,47 @@ pub fn build(b: *std.Build) void {
     const libclipper2_flags = .{ "-std=gnu++17", "-fno-exceptions", "-Dthrow=abort" };
     libclipper2.linkLibC();
     libclipper2.linkSystemLibrary("c++");
-    libclipper2.addIncludePath(.{ .path = "lib/clipper2/CPP/Clipper2Lib" });
-    libclipper2.addIncludePath(.{ .path = "src" });
+    libclipper2.addIncludePath(b.path("lib/clipper2/CPP/Clipper2Lib"));
+    libclipper2.addIncludePath(b.path("src"));
     libclipper2.addCSourceFile(.{
-        .file = .{ .path = "lib/clipper2/CPP/Clipper2Lib/clipper.engine.cpp" },
+        .file = b.path("lib/clipper2/CPP/Clipper2Lib/clipper.engine.cpp"),
         .flags = &libclipper2_flags,
     });
     libclipper2.addCSourceFile(.{
-        .file = .{ .path = "lib/clipper2/CPP/Clipper2Lib/clipper.offset.cpp" },
+        .file = b.path("lib/clipper2/CPP/Clipper2Lib/clipper.offset.cpp"),
         .flags = &libclipper2_flags,
     });
     libclipper2.addCSourceFile(.{
-        .file = .{ .path = "src/clipperwrapper.cpp" },
+        .file = b.path("src/clipperwrapper.cpp"),
         .flags = &libclipper2_flags,
     });
 
-    const libgingerbread = b.addExecutable(.{
-        .name = "gingerbread",
-        .root_source_file = .{ .path = "src/gingerbread.zig" },
-        .version = .{ .major = 1, .minor = 0, .patch = 0 },
-        .target = target,
-        .optimize = optimize,
-        .strip = true
-    });
+    const libgingerbread = b.addExecutable(.{ .name = "gingerbread", .root_source_file = b.path("src/gingerbread.zig"), .version = .{ .major = 1, .minor = 0, .patch = 0 }, .target = target, .optimize = optimize, .strip = true });
     libgingerbread.entry = .disabled;
     libgingerbread.rdynamic = true;
     libgingerbread.wasi_exec_model = std.builtin.WasiExecModel.reactor;
     libgingerbread.linkLibC();
     libgingerbread.linkLibrary(libpotrace);
     libgingerbread.linkLibrary(libclipper2);
-    libgingerbread.addIncludePath(.{ .path = "src" });
-    libgingerbread.addIncludePath(.{ .path = "lib/potrace-1.16/src" });
+    libgingerbread.addIncludePath(b.path("src"));
+    libgingerbread.addIncludePath(b.path("lib/potrace-1.16/src"));
 
     b.installArtifact(libgingerbread);
 
     // const main = b.addTest(.{
     //     .name = "main",
-    //     .root_source_file = .{ .path = "src/tests.zig" },
+    //     .root_source_file = b.path("src/tests.zig"),
     //     .target = target,
     //     .optimize = optimize,
     //     .link_libc = true,
     // });
     // main.linkLibrary(libpotrace);
     // main.linkLibrary(libclipper2);
-    // main.addIncludePath(.{ .path = "src/" });
-    // main.addIncludePath(.{ .path = "lib/potrace-1.16/src" });
-    // main.addIncludePath(.{ .path = "lib/potrace-config" });
-    // main.addIncludePath(.{ .path = "lib/stb" });
-    // main.addCSourceFile(.{ .file = .{ .path = "src/load_image.c" }, .flags = &.{
+    // main.addIncludePath(b.path("src/"));
+    // main.addIncludePath(b.path("lib/potrace-1.16/src"));
+    // main.addIncludePath(b.path("lib/potrace-config"));
+    // main.addIncludePath(b.path("lib/stb"));
+    // main.addCSourceFile(.{ .file = b.path("src/load_image.c"), .flags = &.{
     //     "-std=gnu17",
     // } });
 


### PR DESCRIPTION
I originally tried to build this with Zig 0.13 and it failed because of changes in the internals of `Build.LazyPath`, and after doing some digging, it seems the recommended way forward is using the `Build.path()` helper function, so I did that, which makes it compatible with both 0.12.x and 0.13

I still hit errors after fixing this in 0.13, and ended up switching to 0.12 anyway, but this gets us closer to forwards-compatibility at least.