### PR TITLE
Make hamburger menu on mobile functional, update style overrides

### DIFF
--- a/web/scripts/bulma.js
+++ b/web/scripts/bulma.js
@@ -1,0 +1,22 @@
+// From https://bulma.io/documentation/components/navbar/#navbarJsExample
+document.addEventListener('DOMContentLoaded', () => {
+
+  // Get all "navbar-burger" elements
+  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+
+  // Add a click event on each of them
+  $navbarBurgers.forEach( el => {
+    el.addEventListener('click', () => {
+
+      // Get the target from the "data-target" attribute
+      const target = el.dataset.target;
+      const $target = document.getElementById(target);
+
+      // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
+      el.classList.toggle('is-active');
+      $target.classList.toggle('is-active');
+
+    });
+  });
+
+});

--- a/web/styles/styles.css
+++ b/web/styles/styles.css
@@ -90,20 +90,21 @@ h6 {
 
 /* Section: Links */
 
-a,
-a:focus,
-a:hover {
+a, a:focus {
     color: var(--link-color);
     text-decoration: var(--link-decoration);
 }
 
-a:hover {
+a:hover, a:active {
     color: var(--link-hover-color);
     text-decoration: var(--link-hover-decoration);
 }
 
 a.tags,
-a.tags:hover {
+a.tags:hover,
+a.tags:active,
+a.tags:focus
+{
     text-decoration: none;
 }
 
@@ -112,7 +113,10 @@ a.button::after {
     content: none;
 }
 
-.navbar a, .navbar a:focus, .navbar a:hover {
+.navbar a,
+.navbar a:focus,
+.navbar a:hover,
+.navbar a:active {
     text-decoration: none;
 }
 
@@ -122,7 +126,9 @@ a.button::after {
     background-color: var(--color-Violet);
 }
 
-.button.is-primary:hover {
+.button.is-primary:hover,
+.button.is-primary:active, 
+.button.is-primary:focus {
     background-color: var(--color-Aquarelle);
 }
 
@@ -132,7 +138,9 @@ a.button::after {
     border-color: transparent;
 }
 
-.button.is-alt:hover {
+.button.is-alt:hover,
+.button.is-alt:active,
+.button.is_alt:focus {
     background-color: var(--color-Cupid);
 }
 
@@ -179,7 +187,12 @@ body {
     font-size: 1.5rem;
 }
 
-.navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-end > a.navbar-item:hover {
+.navbar.is-primary .navbar-brand > a.navbar-item:hover,
+.navbar.is-primary .navbar-brand > a.navbar-item:active,
+.navbar.is-primary .navbar-brand > a.navbar-item:focus,
+.navbar.is-primary .navbar-menu a.navbar-item:hover,
+.navbar.is-primary .navbar-menu a.navbar-item:active,
+.navbar.is-primary .navbar-menu a.navbar-item:focus {
     background-color: var(--color-Zinnia);
 }
 

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -33,12 +33,32 @@
             </div>
             <div class="navbar-end">
               <a class="navbar-item" href="help.html">
-                <span class="material-symbols-outlined">
-                  help
+                <span class="is-hidden-touch">
+                  <span class="material-symbols-outlined">
+                    help
+                  </span>
+                </span>
+                <span class="is-hidden-desktop">
+                  <span class="icon-text">
+                    <span class="icon material-symbols-outlined">
+                      help
+                    </span>
+                    <span>Help</span>
+                  </span>
                 </span>
               </a>
               <a class="navbar-item" href="https://github.com/wntrblm/Gingerbread" target="_blank">
-                <img src="./images/github.png"/>
+                <span class="is-hidden-touch">
+                  <img alt="GitHub" src="./images/github.png"/>
+                </span>
+                <span class="is-hidden-desktop">
+                  <span class="icon-text">
+                    <span class="icon">
+                      <img alt="GitHub" src="./images/github.png"/>
+                    </span>
+                    <span class="is-hidden-desktop">GitHub</span>
+                  </span>
+                </span>
               </a>
             </div>
           </div>

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -28,9 +28,9 @@
               <span></span>
             </span>
           </div>
-          <div class="navbar-start">
-          </div>
           <div id="navbarMenuHeroA" class="navbar-menu">
+            <div class="navbar-start">
+            </div>
             <div class="navbar-end">
               <a class="navbar-item" href="help.html">
                 <span class="material-symbols-outlined">

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gingerbread</title>
   <link rel="stylesheet" href="./styles/styles.css">
+  <script defer type="text/javascript" src="./scripts/bulma.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
The hamburger menu doesn't actually work without some added Javascript, so I added that, and then also added labels to the icons when they're in the open menu. I also noticed that when clicking on or tabbing to the menu buttons they rendered as white-on-white, so I reworked the overrides a bit to fix that.

The overrides and the icon buttons are a bit verbose, but as mentioned in the commit messages, ime that's just kinda part of the tradeoff of an opinionated CSS framework like Bulma. We could probably do less overriding by using the customization facilities, but that requires either building our own CSS file from SASS or upgrading to 1.0, so I just patched things for now.